### PR TITLE
Use first image by position

### DIFF
--- a/app/models/spree/feed_product.rb
+++ b/app/models/spree/feed_product.rb
@@ -51,7 +51,7 @@ module Spree
 
     def image_link
       return unless product.images.any?
-      product.images.first.attachment.url(:original)
+      product.display_image.attachment.url(:original)
     end
   end
 end

--- a/spec/models/spree/feed_product_spec.rb
+++ b/spec/models/spree/feed_product_spec.rb
@@ -34,8 +34,23 @@ RSpec.describe Spree::FeedProduct do
   describe "#image_link" do
     subject { feed_product.image_link }
     context "when the product has images" do
-      before { Spree::Image.create! viewable: product.master, attachment_file_name: 'hams.png' }
+      let!(:image_1) {
+        Spree::Image.create! viewable: product.master, attachment_file_name: 'hams.png'
+      }
       it { is_expected.to eq '/spree/products/1/original/hams.png' }
+      it { is_expected.to eq image_1.attachment.url(:original) }
+
+      context "and the display image isn't the first one added" do
+        let!(:image_2) {
+          Spree::Image.create! viewable: product.master, attachment_file_name: 'sausages.png'
+        }
+        before do
+          product.reload.images.last.move_higher
+        end
+
+        it { is_expected.to eq image_2.attachment.url(:original) }
+
+      end
     end
 
     context "when the product doesn't have images" do


### PR DESCRIPTION
Previously, it was possible that the feed image link would point to the
image that was not first when ordered by position. By using
`display_image` we should be confident that we're getting the proper
image.