### PR TITLE
Don't set URL or path for Spree::Image attachment

### DIFF
--- a/app/models/spree/image_decorator.rb
+++ b/app/models/spree/image_decorator.rb
@@ -3,8 +3,6 @@ Spree::Image.class_eval do
                     styles: proc { |attachment| attachment.instance.styles },
                     default_style: :product,
                     default_url: 'noimage/:style.png',
-                    url: '/spree/products/:id/:style/:basename.:extension',
-                    path: ':rails_root/public/spree/products/:id/:style/:basename.:extension',
                     convert_options: { mini: '-strip -auto-orient -colorspace sRGB',
                                        small: '-strip -auto-orient -colorspace sRGB',
                                        product: '-strip -auto-orient -colorspace sRGB',


### PR DESCRIPTION
We remove those in an initializer, so don't set them here either. For reference, the removal happens at
https://github.com/geminimvp/engine_storefront/blob/d31d44a517d39d99b1aa8e335d29b2e9c8e91666/config/initializers/paperclip.rb#L17