### PR TITLE
Restore call to super on ProductsController#index

### DIFF
--- a/app/controllers/spree/products_controller_decorator.rb
+++ b/app/controllers/spree/products_controller_decorator.rb
@@ -1,19 +1,19 @@
-Spree::ProductsController.class_eval do
-  before_action(only: :index) do |controller|
-    if controller.request.format.rss?
-      load_feed_products
+Spree::ProductsController.prepend(Module.new do
+  class << self
+    def prepended(klass)
+      klass.respond_to :rss, :xml, only: :index
     end
   end
 
   def index
+    load_feed_products if request.format.rss? || request.format.xml?
     respond_to do |format|
       if product_feed
         format.rss { render inline: xml.generate, layout: false }
       else
         format.rss { redirect_to action: 'index' }
       end
-
-      format.html
+      format.html { super }
     end
   end
 
@@ -41,4 +41,4 @@ Spree::ProductsController.class_eval do
   def xml
     @xml ||= Spree::Feeds::XML.new(@feed_products, current_store)
   end
-end
+end)

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -25,5 +25,17 @@ describe Spree::ProductsController do
       subject
       expect(response.content_type).to eq 'application/rss+xml'
     end
+
+    context 'GET #index as html' do
+      it 'is successful' do
+        get :index
+        expect(response).to be_successful
+      end
+
+      it 'makes products available' do
+        get :index
+        expect(assigns(:products)).to be_present
+      end
+    end
   end
 end

--- a/spec/services/spree/product_feed_service_spec.rb
+++ b/spec/services/spree/product_feed_service_spec.rb
@@ -119,9 +119,10 @@ describe Spree::ProductFeedService do
 
   describe '#image_link' do
     subject { service.image_link }
+    let(:image_path_regex) { /http:\/\/example.com\/system\/spree\/images\/attachments\/\d*\/\d*\/\d*\/product_feed\/hams.png/ }
 
     context 'when the variant has images' do
-      it { is_expected.to eq('http://example.com/spree/products/2/product_feed/hams.png') }
+      it { is_expected.to match(image_path_regex) }
     end
 
     context 'when the product has images' do
@@ -130,7 +131,7 @@ describe Spree::ProductFeedService do
         allow_any_instance_of(Spree::Product).to receive(:images).and_return([product_image])
       end
 
-      it { is_expected.to eq('http://example.com/spree/products/1/product_feed/hams.png') }
+      it { is_expected.to match(image_path_regex) }
     end
 
     context "when the product an variant don't have images" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ ENV['RAILS_ENV'] = 'test'
 require File.expand_path('../dummy/config/environment.rb', __FILE__)
 
 require 'rspec/rails'
+require 'devise'
 
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
 
@@ -12,6 +13,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.include Spree::TestingSupport::UrlHelpers
   config.include Spree::Api::TestingSupport::Helpers
+  config.include Devise::Test::ControllerHelpers, type: :controller
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = false
   config.fail_fast = ENV['FAIL_FAST'] || false


### PR DESCRIPTION
- Fixes a bug that caused engine_storefront product grids to be empty because the original ProductsController#index method from solidus was no longer being run.
- Use Module#prepend rather than class eval to monkeypatch Spree::ProductsController so that the original index method is available
- Call `super` when responding to HTML-format requests to ProductsController#index