### PR TITLE
Account for host / hostless image links

### DIFF
--- a/app/services/spree/product_feed_service.rb
+++ b/app/services/spree/product_feed_service.rb
@@ -101,8 +101,23 @@ module Spree
     end
 
     def image_link
-      return "#{store.url}#{variant.try(:images).first.try(:attachment).try(:url, :product_feed)}" if variant.images.any?
-      return "#{store.url}#{product.try(:images).first.try(:attachment).try(:url, :product_feed)}" if product.images.any?
+      if image_link_base =~ /\Ahttp/
+        return image_link_base
+      elsif image_link_base.present?
+        return "#{store.url}#{image_link_base}"
+      end
+    end
+
+    def image_link_base
+      if variant.images.any?
+        item_product_feed_image_link(variant)
+      elsif product.images.any?
+        item_product_feed_image_link(product)
+      end
+    end
+
+    def item_product_feed_image_link(item)
+      item.try(:images).first.try(:attachment).try(:url, :product_feed)
     end
   end
 end

--- a/spec/services/spree/product_feed_service_spec.rb
+++ b/spec/services/spree/product_feed_service_spec.rb
@@ -119,7 +119,13 @@ describe Spree::ProductFeedService do
 
   describe '#image_link' do
     subject { service.image_link }
-    let(:image_path_regex) { /http:\/\/example.com\/system\/spree\/images\/attachments\/\d*\/\d*\/\d*\/product_feed\/hams.png/ }
+
+    let(:expected_image_path) {
+      'http://example.com/system/spree/images/attachments/\d*/\d*/\d*/product_feed/hams.png'
+    }
+    let(:image_path_regex) {
+      %r|\A#{expected_image_path}\Z|
+    }
 
     context 'when the variant has images' do
       it { is_expected.to match(image_path_regex) }


### PR DESCRIPTION
When generating an image link for a product feed, we may need to prepend
the Store's hostname. We also... may not need to! In production, `url`
returns a fully formed URL. In test, however, `url` appears to be the
local path to the image. While it's not great to write code for test, I
think this is flexible and intention-revealing enough to avoid muddying
the waters.