### PR TITLE
Re-add support for XML request format

### DIFF
--- a/app/controllers/spree/products_controller_decorator.rb
+++ b/app/controllers/spree/products_controller_decorator.rb
@@ -6,12 +6,14 @@ Spree::ProductsController.prepend(Module.new do
   end
 
   def index
-    load_feed_products if request.format.rss? || request.format.xml?
+    load_feed_products if (request.format.rss? || request.format.xml?)
     respond_to do |format|
       if product_feed
         format.rss { render inline: xml.generate, layout: false }
+        format.xml { render inline: xml.generate, layout: false }
       else
         format.rss { redirect_to action: 'index' }
+        format.xml { redirect_to action: 'index' }
       end
       format.html { super }
     end

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -26,6 +26,19 @@ describe Spree::ProductsController do
       expect(response.content_type).to eq 'application/rss+xml'
     end
 
+    context 'as XML' do
+      subject { get :index, params: { format: 'xml' } }
+
+      it 'returns the correct http code' do
+        is_expected.to have_http_status :ok
+      end
+
+      it 'returns the correct content type' do
+        subject
+        expect(response.content_type).to eq 'application/xml'
+      end
+    end
+
     context 'GET #index as html' do
       it 'is successful' do
         get :index


### PR DESCRIPTION
A recent change caused our support for `/products.xml` to break, so we
need to restore that capability.