### PR TITLE
Optimize product feed SQL queries

### DIFF
--- a/app/controllers/spree/products_controller_decorator.rb
+++ b/app/controllers/spree/products_controller_decorator.rb
@@ -7,6 +7,7 @@ Spree::ProductsController.prepend(Module.new do
 
   def index
     load_feed_products if (request.format.rss? || request.format.xml?)
+
     respond_to do |format|
       if product_feed
         format.rss { render inline: xml.generate, layout: false }
@@ -22,14 +23,9 @@ Spree::ProductsController.prepend(Module.new do
   private
 
   def load_feed_products
-    items = []
     product_catalog = product_feed.try(:product_catalog)
-
-    Spree::Variant.where(id: product_catalog.item_ids).each do |variant|
-      items << Spree::ProductFeedService.new(variant)
-    end if product_catalog
-
-    @feed_products = items
+    item_ids = product_catalog ? product_catalog.item_ids : []
+    @feed_products = Spree::Variant.where(id: item_ids)
   end
 
   def product_feed

--- a/app/services/spree/feeds/base.rb
+++ b/app/services/spree/feeds/base.rb
@@ -1,15 +1,33 @@
 module Spree
   module Feeds
     class Base
-      attr_reader :items, :store
+      attr_reader :variants, :store
 
-      def initialize(items, store = Spree::Store.default)
-        @items = items
+      def initialize(variants, store = Spree::Store.default)
+        @variants = variants
         @store = store
       end
 
       def generate
         raise NotImplementedError, "Please implement 'generate' in your feed: #{self.class}"
+      end
+
+      # This is used in all feed types to reduce the volume of SQL queries
+      def variants_includes
+        [
+          :images,
+          {
+            product: [
+              { product_properties: :property },
+              { master: [:images, :variant_image_images] },
+              { taxons: :taxonomy },
+            ],
+          },
+          { option_values: :option_type },
+          :variant_image_images,
+          :default_price,
+        ]
+
       end
     end
   end

--- a/app/services/spree/feeds/csv.rb
+++ b/app/services/spree/feeds/csv.rb
@@ -8,7 +8,8 @@ module Spree
         ::CSV.generate do |csv|
           csv << header_node
 
-          items.each do |item|
+          variants.includes(variants_includes).find_each(batch_size: 100) do |variant|
+            item = Spree::ProductFeedService.new(variant)
             csv << item_node(item)
           end
         end

--- a/app/services/spree/feeds/xml.rb
+++ b/app/services/spree/feeds/xml.rb
@@ -12,8 +12,8 @@ module Spree
             xml.title store.name
             xml.link store.url
             xml.description "Find out about new products on http://#{store.url} first!"
-
-            items.each do |item|
+            variants.includes(variants_includes).find_each(batch_size: 100) do |variant|
+              item = Spree::ProductFeedService.new(variant, store)
               xml.item do
                 xml.tag! 'g:id', item.id
                 xml.tag! 'g:title', item.title


### PR DESCRIPTION
STATUS: I commented out all of the XML tags and started re-adding them
one at a time to spot which ones generated new SQL queries. In the
process, I discovered that several of the attribute methods on
`ProductFeedService` rely on Product Properties when they should be
targeting Taxons, and thus they would not work on any of our current
stores.

NEXT STEPS: uncomment more of the XML tags, figure out how to derive
gender / etc. from taxons instead of from ProductProperties.