### PR TITLE
Fix broken specs

### DIFF
--- a/app/services/spree/feeds/base.rb
+++ b/app/services/spree/feeds/base.rb
@@ -13,21 +13,36 @@ module Spree
       end
 
       # This is used in all feed types to reduce the volume of SQL queries
-      def variants_includes
+      def variants_includes_base
         [
           :images,
           {
             product: [
               { product_properties: :property },
-              { master: [:images, :variant_image_images] },
+              { master: master_variant_includes },
               { taxons: :taxonomy },
             ],
           },
           { option_values: :option_type },
-          :variant_image_images,
           :default_price,
         ]
+      end
 
+      def master_variant_includes
+        [:images].tap do |mv_includes|
+          if Spree::Variant.respond_to?(:variant_image_images)
+            mv_includes << :variant_image_images
+          end
+        end
+      end
+
+      def variants_includes
+        if Spree::Variant.respond_to?(:variant_image_images)
+          base = variants_includes_base
+          base << :variant_image_images
+        else
+          variants_includes_base
+        end
       end
     end
   end

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -14,6 +14,12 @@ describe Spree::ProductsController do
            store: store)
   end
 
+  before do
+    # This attribute is added by the `solidus_asset_variant_options`
+    # extension which isn't an explicit dependency of this gem.
+    allow_any_instance_of(Spree::Variant).to receive(:variant_image_images).and_return([])
+  end
+
   context 'GET #index' do
     subject { get :index, params: { format: 'rss' } }
 


### PR DESCRIPTION
Recent changes to this gem were quickly tested in `engine_storefront`
but not here directly since this repo has no CI set up. We need to bring
the local specs back to green status to support further development.

I did not enjoy writing the code to account for `variant_image_images` as that seems very specific to us, but we are already on our own branch so it seemed like the cleaner solution.