### PR TITLE
Fb feed conformance

### DIFF
--- a/app/services/spree/product_feed_service.rb
+++ b/app/services/spree/product_feed_service.rb
@@ -27,7 +27,14 @@ module Spree
     end
 
     def url
-      "#{store.url}/#{product.slug}"
+      base_url = "#{store.url}/#{product.slug}"
+
+      if base_url =~ /\Ahttp/
+        base_url
+      else
+        "https://#{base_url}"
+      end
+
     end
 
     def color
@@ -87,7 +94,7 @@ module Spree
       if image_link_base =~ /\Ahttp/
         return image_link_base
       elsif image_link_base.present?
-        return "#{store.url}#{image_link_base}"
+        return "https://#{store.url}#{image_link_base}"
       end
     end
 

--- a/spec/services/spree/product_feed_service_spec.rb
+++ b/spec/services/spree/product_feed_service_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Spree::ProductFeedService do
-  let!(:store) { create(:store, default: true, url: 'http://example.com') }
+  let(:store_url) { 'example.com' }
+  let!(:store) { create(:store, default: true, url: store_url) }
   let!(:gender) do
     create(:property, name: 'Gender', presentation: 'Gender')
   end
@@ -86,7 +87,11 @@ describe Spree::ProductFeedService do
   describe '#url' do
     subject { service.url }
 
-    it { is_expected.to eq("#{store.url}/#{product.slug}") }
+    it { is_expected.to eq("https://#{store.url}/#{product.slug}") }
+    context 'when store URL already includes protocol' do
+      let(:store_url) { 'https://example.com' }
+      it { is_expected.to eq("#{store.url}/#{product.slug}") }
+    end
   end
 
   describe '#condition' do
@@ -129,7 +134,7 @@ describe Spree::ProductFeedService do
     subject { service.image_link }
 
     let(:expected_image_path) {
-      'http://example.com/system/spree/images/attachments/\d*/\d*/\d*/large/hams.png'
+      'https://example.com/system/spree/images/attachments/\d*/\d*/\d*/large/hams.png'
     }
     let(:image_path_regex) {
       %r|\A#{expected_image_path}\Z|


### PR DESCRIPTION
These commits contain fixes to bring our product feed up to facebook's feed data standards. I based this off of the `fix_specs` branch so that I could drive development using working tests.