### PR TITLE
Select product feed image by position

### DIFF
--- a/app/services/spree/product_feed_service.rb
+++ b/app/services/spree/product_feed_service.rb
@@ -112,7 +112,16 @@ module Spree
     end
 
     def item_product_feed_image_link(item)
-      item.try(:images).first.try(:attachment).try(:url, :large)
+      item_product_feed_image(item)&.attachment&.url(:large)
+    end
+
+    # Determine which image to use for this variant/product in the feed
+    def item_product_feed_image(item)
+      if item.images.present?
+        item.images.order(:position).first
+      elsif item&.product&.present?
+        item.product.display_image
+      end
     end
 
     private


### PR DESCRIPTION
When determining which image to link in the product feed, select the
first image as ordered by the `position` attribute. This is a
re-implementation of a previous fix that was lost during the transition
to custom feeds.