### PR TITLE
Easy default feed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,11 @@ gem 'solidus_auth_devise'
 gem 'deface'
 
 if branch == 'master' || branch >= 'v2.3'
-  gem 'rails', '~> 5.1.4'
+  gem 'rails', '~> 5.2.0'
 elsif branch >= 'v2.0'
   gem 'rails', '~> 5.0.6'
 end
+gem 'sprockets', '< 4.0.0'
 
 gem 'mysql2', '~> 0.4.10'
 gem 'pg', '~> 0.21'

--- a/app/controllers/spree/products_controller_decorator.rb
+++ b/app/controllers/spree/products_controller_decorator.rb
@@ -9,13 +9,8 @@ Spree::ProductsController.prepend(Module.new do
     load_feed_products if (request.format.rss? || request.format.xml?)
 
     respond_to do |format|
-      if product_feed
-        format.rss { render inline: xml.generate, layout: false }
-        format.xml { render inline: xml.generate, layout: false }
-      else
-        format.rss { redirect_to action: 'index' }
-        format.xml { redirect_to action: 'index' }
-      end
+      format.rss { render inline: xml.generate, layout: false }
+      format.xml { render inline: xml.generate, layout: false }
       format.html { super }
     end
   end
@@ -23,9 +18,23 @@ Spree::ProductsController.prepend(Module.new do
   private
 
   def load_feed_products
-    product_catalog = product_feed.try(:product_catalog)
-    item_ids = product_catalog ? product_catalog.item_ids : []
     @feed_products = Spree::Variant.where(id: item_ids)
+  end
+
+  def item_ids
+    if product_catalog
+      product_catalog.item_ids
+    else
+      all_variant_ids
+    end
+  end
+
+  def all_variant_ids
+    Spree::Variant.pluck(:id)
+  end
+
+  def product_catalog
+    @product_catalog ||= product_feed.try(:product_catalog)
   end
 
   def product_feed

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -2,17 +2,8 @@ require 'spec_helper'
 
 describe Spree::ProductsController do
   let!(:store) { create(:store) }
-  let(:product) { create(:product, name: '2 Hams', price: 20.00) }
-  let(:variant) { create(:variant, product: product) }
-  let!(:product_catalog) do
-    create(:product_catalog, item_ids: [variant.id.to_s], store: store)
-  end
-  let!(:product_feed) do
-    create(:product_feed,
-           name: 'Test',
-           product_catalog: product_catalog,
-           store: store)
-  end
+  let!(:product) { create(:product, name: '2 Hams', price: 20.00) }
+  let!(:variant) { create(:variant, product: product) }
 
   before do
     # This attribute is added by the `solidus_asset_variant_options`
@@ -20,32 +11,61 @@ describe Spree::ProductsController do
     allow_any_instance_of(Spree::Variant).to receive(:variant_image_images).and_return([])
   end
 
-  context 'GET #index' do
+  describe 'GET #index' do
     subject { get :index, params: { format: 'rss' } }
 
-    it 'returns the http correct code' do
-      is_expected.to have_http_status :ok
-    end
-
-    it 'returns the correct content type' do
-      subject
-      expect(response.content_type).to eq 'application/rss+xml'
-    end
-
-    context 'as XML' do
-      subject { get :index, params: { format: 'xml' } }
-
-      it 'returns the correct http code' do
+    context 'when no product feed exists' do
+      it 'returns HTTP success' do
         is_expected.to have_http_status :ok
       end
 
       it 'returns the correct content type' do
         subject
-        expect(response.content_type).to eq 'application/xml'
+        expect(response.content_type).to eq 'application/rss+xml'
+      end
+
+      it 'includes the correct products' do
+        subject
+        expect(response.body).to include(variant.sku)
       end
     end
 
-    context 'GET #index as html' do
+    context 'when a product feed exists' do
+      let!(:product_catalog) do
+        create(:product_catalog, item_ids: [variant.id.to_s], store: store)
+      end
+      let!(:product_feed) do
+        create(:product_feed,
+               name: 'Test',
+               product_catalog: product_catalog,
+               store: store)
+      end
+
+      it 'returns the http correct code' do
+        is_expected.to have_http_status :ok
+      end
+
+      it 'returns the correct content type' do
+        subject
+        expect(response.content_type).to eq 'application/rss+xml'
+      end
+
+      context 'as XML' do
+        subject { get :index, params: { format: 'xml' } }
+
+        it 'returns the correct http code' do
+          is_expected.to have_http_status :ok
+        end
+
+        it 'returns the correct content type' do
+          subject
+          expect(response.content_type).to eq 'application/xml'
+        end
+      end
+
+    end
+
+    context 'as html' do
       it 'is successful' do
         get :index
         expect(response).to be_successful

--- a/spec/services/spree/product_feed_service_spec.rb
+++ b/spec/services/spree/product_feed_service_spec.rb
@@ -199,10 +199,13 @@ describe Spree::ProductFeedService do
 
     context 'when product has a taxon with no taxonomy' do
       let(:orphan_root) {
-        create(:taxon, name: 'Warbucks', taxonomy_id: nil)
+        oroot = create(:taxon, name: 'Warbucks')
+        oroot.update_columns(taxonomy_id: nil)
+        oroot
       }
       let(:orphan_taxon) {
-        taxon = create(:taxon, name: 'Annie', taxonomy_id: nil)
+        taxon = create(:taxon, name: 'Annie')
+        taxon.update_columns(taxonomy_id: nil)
         taxon.move_to_child_of(orphan_root)
         taxon
       }


### PR DESCRIPTION
Restore some of the old "easy default" behavior for product feeds. This should make everyone's life easier since feeds will stay up to date automatically.