### PR TITLE
Feed accepts header

### DIFF
--- a/app/controllers/spree/products_controller_decorator.rb
+++ b/app/controllers/spree/products_controller_decorator.rb
@@ -1,7 +1,8 @@
 Spree::ProductsController.prepend(Module.new do
   class << self
     def prepended(klass)
-      klass.respond_to :rss, :xml, only: :index
+      klass.respond_to :html, :rss, :xml, only: :index
+      klass.before_action :default_format_html
     end
   end
 
@@ -9,9 +10,9 @@ Spree::ProductsController.prepend(Module.new do
     load_feed_products if (request.format.rss? || request.format.xml?)
 
     respond_to do |format|
+      format.all { super }
       format.rss { render inline: xml.generate, layout: false }
       format.xml { render inline: xml.generate, layout: false }
-      format.html { super }
     end
   end
 
@@ -47,5 +48,12 @@ Spree::ProductsController.prepend(Module.new do
 
   def xml
     @xml ||= Spree::Feeds::XML.new(@feed_products, current_store)
+  end
+
+  # Force `*/*` requests to be interpreted as HTML
+  def default_format_html
+    if params[:format].blank?
+      request.format = "html"
+    end
   end
 end)

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -63,6 +63,24 @@ describe Spree::ProductsController do
         end
       end
 
+      context 'as anything' do
+        subject { get :index, params: {} }
+
+        before do
+          request.headers['Accept'] = '*/*'
+        end
+
+        it 'returns the correct http code' do
+          is_expected.to have_http_status :ok
+        end
+
+        it 'returns the correct content type' do
+          subject
+          expect(response.content_type).to eq 'text/html'
+        end
+
+      end
+
     end
 
     context 'as html' do


### PR DESCRIPTION
We have received some requests for `/products` that contain an ambiguous Accept: HTTP header of `*/*`. This really confuses the controller action, so we default it to HTML if no format is provided.