### PR TITLE
Improve feed request performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,21 @@ sudo: false
 cache: bundler
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.4
+services:
+  - mysql
+  - postgresql
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.0 DB=postgres
-    - SOLIDUS_BRANCH=v2.1 DB=postgres
-    - SOLIDUS_BRANCH=v2.2 DB=postgres
-    - SOLIDUS_BRANCH=v2.3 DB=postgres
-    - SOLIDUS_BRANCH=v2.4 DB=postgres
     - SOLIDUS_BRANCH=v2.5 DB=postgres
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
+    - SOLIDUS_BRANCH=v2.8 DB=postgres
+    - SOLIDUS_BRANCH=v2.9 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v2.0 DB=mysql
-    - SOLIDUS_BRANCH=v2.1 DB=mysql
-    - SOLIDUS_BRANCH=v2.2 DB=mysql
-    - SOLIDUS_BRANCH=v2.3 DB=mysql
-    - SOLIDUS_BRANCH=v2.4 DB=mysql
     - SOLIDUS_BRANCH=v2.5 DB=mysql
     - SOLIDUS_BRANCH=v2.6 DB=mysql
     - SOLIDUS_BRANCH=v2.7 DB=mysql
+    - SOLIDUS_BRANCH=v2.8 DB=mysql
+    - SOLIDUS_BRANCH=v2.9 DB=mysql
     - SOLIDUS_BRANCH=master DB=mysql

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,10 @@ gem 'solidus', github: 'solidusio/solidus', branch: branch
 gem 'solidus_auth_devise'
 gem 'deface'
 
-if branch == 'master' || branch >= 'v2.3'
+if branch == 'master' || branch >= 'v2.6'
   gem 'rails', '~> 5.2.0'
-elsif branch >= 'v2.0'
-  gem 'rails', '~> 5.0.6'
+elsif branch >= 'v2.4'
+  gem 'rails', '~> 5.1.0'
 end
 gem 'sprockets', '< 4.0.0'
 

--- a/app/controllers/spree/products_controller_decorator.rb
+++ b/app/controllers/spree/products_controller_decorator.rb
@@ -19,7 +19,11 @@ Spree::ProductsController.prepend(Module.new do
   private
 
   def load_feed_products
-    @feed_products = Spree::Variant.where(id: item_ids)
+    @feed_products = if product_catalog
+                       Spree::Variant.where(id: item_ids)
+                     else
+                       Spree::Variant.available
+                     end
   end
 
   def item_ids

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,0 +1,10 @@
+module Spree
+  module ProductFeedProductDecorator
+    def self.prepended(base)
+      base.has_one :brand_classification, -> { includes(taxon: :taxonomy).references(:taxonomy).where(spree_taxonomies: { name: 'Brand' }) }, class_name: 'Spree::Classification'
+      base.has_one :brand_taxon, -> { includes(:taxonomy).references(:taxonomy) }, through: :brand_classification, source: :taxon
+    end
+
+    Spree::Product.prepend self
+  end
+end

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,9 +1,21 @@
 Spree::Variant.class_eval do
+  def self.available
+    includes(:product).references(:product).where("spree_products.available_on <= ?", Time.zone.now)
+  end
+
   def product_feed_image
     images.where(viewable_type: 'Spree::ProductCatalog').first
   end
 
   def display_option_text
     options_text.present? && options_text || 'Master Variant'
+  end
+
+  def first_image
+    if respond_to?(:gallery)
+      gallery.images.first
+    else
+      display_image
+    end
   end
 end

--- a/app/services/spree/feeds/base.rb
+++ b/app/services/spree/feeds/base.rb
@@ -6,6 +6,7 @@ module Spree
       def initialize(variants, store = Spree::Store.default)
         @variants = variants
         @store = store
+        @products = {}
       end
 
       def generate
@@ -13,36 +14,19 @@ module Spree
       end
 
       # This is used in all feed types to reduce the volume of SQL queries
-      def variants_includes_base
+      def variants_includes
         [
-          :images,
-          {
-            product: [
-              { product_properties: :property },
-              { master: master_variant_includes },
-              { taxons: :taxonomy },
-            ],
-          },
-          { option_values: :option_type },
           :default_price,
+          :option_values_variants,
+          { option_values: :option_type },
         ]
       end
 
-      def master_variant_includes
-        [:images].tap do |mv_includes|
-          if Spree::Variant.respond_to?(:variant_image_images)
-            mv_includes << :variant_image_images
-          end
+      def fetch_product(product_id)
+        if @products[product_id].blank?
+          @products[product_id] = Spree::Product.includes(:master, :brand_taxon, { product_properties: :property }).find_by(id: product_id)
         end
-      end
-
-      def variants_includes
-        if Spree::Variant.respond_to?(:variant_image_images)
-          base = variants_includes_base
-          base << :variant_image_images
-        else
-          variants_includes_base
-        end
+        @products[product_id]
       end
     end
   end

--- a/solidus_product_feed.gemspec
+++ b/solidus_product_feed.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus', solidus_version
   s.add_dependency 'solidus_support'
   s.add_dependency 'deface'
+  s.add_dependency 'ox'
 
   s.add_development_dependency 'capybara', '~> 2.18'
   s.add_development_dependency 'poltergeist'

--- a/spec/services/spree/product_feed_service_spec.rb
+++ b/spec/services/spree/product_feed_service_spec.rb
@@ -146,8 +146,8 @@ describe Spree::ProductFeedService do
 
     context 'when the product has images' do
       before do
-        allow_any_instance_of(Spree::Variant).to receive(:images).and_return([])
-        allow_any_instance_of(Spree::Product).to receive(:images).and_return([product_image])
+        allow(variant).to receive(:images) { [] }
+        allow(product.master).to receive(:images) { [product_image] }
       end
 
       it { is_expected.to match(image_path_regex) }
@@ -155,8 +155,10 @@ describe Spree::ProductFeedService do
 
     context "when the product an variant don't have images" do
       before do
-        allow_any_instance_of(Spree::Product).to receive(:images).and_return([])
-        allow_any_instance_of(Spree::Variant).to receive(:images).and_return([])
+        allow(variant).to receive(:images) { [] }
+        allow(variant).to receive(:display_image) { nil }
+        allow(product.master).to receive(:images) { [] }
+        allow(product.master).to receive(:display_image) { nil }
       end
 
       it { is_expected.to be_nil }


### PR DESCRIPTION
In order to serve product feeds containing thousands of variants in under 30 seconds (Heroku's hard cap) we need to make some improvements and optimizations to how the feed is generated. By caching frequently used objects we can cut down on the number of objects instantiated.