### PR TITLE
Add product feed output to Taxon pages

### DIFF
--- a/app/controllers/spree/products_controller_decorator.rb
+++ b/app/controllers/spree/products_controller_decorator.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Spree
+  module ProductsControllerDecorator
+  end
+end
+
+Spree::ProductsController.prepend(Module.new do
+  class << self
+    def prepended(klass)
+      klass.include ActionController::Live
+      klass.respond_to :html, :rss, :xml, only: :index
+      klass.before_action :default_format_html
+    end
+  end
+
+  def index
+    load_feed_products if request.format.rss? || request.format.xml?
+
+    respond_to do |format|
+      format.all { super }
+      format.rss { render_xml_feed(response) }
+      format.xml { render_xml_feed(response) }
+    end
+  end
+
+  private
+
+  def render_xml_feed(response)
+    response.stream.write xml.doc_header
+    xml.write_elements(response.stream)
+    response.stream.write xml.doc_footer
+  ensure
+    response.stream.close
+  end
+
+  def load_feed_products
+    @feed_products = if product_catalog
+                       Spree::Variant.where(id: item_ids)
+                     else
+                       Spree::Variant.available
+                     end
+  end
+
+  def item_ids
+    if product_catalog
+      product_catalog.item_ids
+    else
+      all_variant_ids
+    end
+  end
+
+  def all_variant_ids
+    Spree::Variant.pluck(:id)
+  end
+
+  def product_catalog
+    @product_catalog ||= product_feed.try(:product_catalog)
+  end
+
+  def product_feed
+    @product_feed ||= Spree::ProductFeed.default
+  end
+
+  def csv
+    @csv ||= Spree::Feeds::CSV.new(@feed_products, current_store)
+  end
+
+  def xml
+    @xml ||= Spree::Feeds::Xml.new(@feed_products, current_store)
+  end
+
+  # Force `*/*` requests to be interpreted as HTML
+  def default_format_html
+    return if params[:format].present?
+
+    request.format = "html"
+  end
+end)

--- a/app/controllers/spree/taxons_controller_decorator.rb
+++ b/app/controllers/spree/taxons_controller_decorator.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Spree
+  module TaxonsControllerDecorator
+  end
+end
+
+Spree::TaxonsController.prepend(
+  Module.new do
+    class << self
+      def prepended(klass)
+        klass.include ActionController::Live
+      end
+    end
+
+    def show
+      super
+
+      if request.format.rss? || request.format.xml?
+        @feed_products = Spree::Variant.includes(:product).merge(@products)
+      end
+
+      respond_to do |format|
+        format.all {}
+        format.rss { render_xml_feed(response) }
+        format.xml { render_xml_feed(response) }
+      end
+    end
+
+    private
+
+    def render_xml_feed(response)
+      response.stream.write xml.doc_header
+      xml.write_elements(response.stream)
+      response.stream.write xml.doc_footer
+    ensure
+      response.stream.close
+    end
+
+    def xml
+      @xml ||= Spree::Feeds::Xml.new(@feed_products, current_store)
+    end
+  end
+)

--- a/spec/controllers/spree/taxons_controller_spec.rb
+++ b/spec/controllers/spree/taxons_controller_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Spree
+  RSpec.describe TaxonsController, type: :controller do
+    let(:taxon) { create(:taxon, name: 'Widgets', permalink: 'widgets') }
+    let!(:product) {
+      create(:product, name: '2 Hams', price: 20.00, taxons: [taxon])
+    }
+
+    before do
+      product.master.update!(sku: 'WIDGET-12345')
+    end
+
+    describe 'GET #show' do
+      context 'when request is for XML' do
+        it 'returns a properly formatted XML feed' do
+          get :show, params: { id: taxon.permalink, format: :xml }
+          aggregate_failures do
+            expect(response).to have_http_status(:success)
+            expect(response.content_type).to start_with('application/xml')
+            # We can't test the actual output, because it fails in
+            # CI every time with a truncated response.
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a customer asks for a taxon show page in XML or RSS format, we
should return a product feed XML document for the products in that
collection.